### PR TITLE
[api-patch] Remove `Buffer` deprecation error

### DIFF
--- a/src/display/api.js
+++ b/src/display/api.js
@@ -542,17 +542,6 @@ function getUrlProp(val) {
 
 function getDataProp(val) {
   // Converting string or array-like data to Uint8Array.
-  if (
-    typeof PDFJSDev !== "undefined" &&
-    PDFJSDev.test("GENERIC") &&
-    isNodeJS &&
-    typeof Buffer !== "undefined" && // eslint-disable-line no-undef
-    val instanceof Buffer // eslint-disable-line no-undef
-  ) {
-    throw new Error(
-      "Please provide binary data as `Uint8Array`, rather than `Buffer`."
-    );
-  }
   if (val instanceof Uint8Array && val.byteLength === val.buffer.byteLength) {
     // Use the data as-is when it's already a Uint8Array that completely
     // "utilizes" its underlying ArrayBuffer, to prevent any possible


### PR DESCRIPTION
#16055 first added a deprecation warning, but #16627 made it an error.

Since `Buffer` is a subclass of `Uint8Array` (see https://nodejs.org/api/buffer.html#buffer), the wrap was never necessary anyways, hence the removal of this code

> The `Buffer` class is a subclass of JavaScript's [Uint8Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array) class and extends it with methods that cover additional use cases.

[This CodeSandbox](https://codesandbox.io/s/upbeat-dijkstra-ymhst6?file=/src/index.js&expanddevtools=1) also shows you that `buffer instanceof Uint8Array` returns `true`

CC/ @Snuffleupagus @timvandermeij
